### PR TITLE
v1.2: AI自律開発基盤（Preview/Screenshot/GameCommand/ConsoleLog/CacheClean）

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ curl http://127.0.0.1:3000/health
 | `debug_get_editor_info` | Get editor version and environment |
 | `debug_list_messages` | List available Editor messages |
 | `debug_execute_script` | Execute scene script method |
-| `debug_get_console_logs` | Get console log entries |
-| `debug_clear_console` | Clear editor console |
+| `debug_get_console_logs` | Get console log entries (scene + game preview) |
+| `debug_clear_console` | Clear editor console and log buffers |
 | `debug_list_extensions` | List installed extensions |
 | `debug_get_extension_info` | Get extension details |
 | `debug_get_project_logs` | Read project log entries |
@@ -306,6 +306,65 @@ curl http://127.0.0.1:3000/health
 | `refimage_refresh` | Refresh image display |
 </details>
 
+## Console Log Capture
+
+`debug_get_console_logs` captures logs from two sources:
+
+### Scene Process Logs (automatic)
+
+Console output from scene scripts (`console.log/warn/error` in the scene renderer process) is automatically captured. No setup required.
+
+### Game Preview Logs (opt-in)
+
+Game code runs in a browser during preview, which is a separate process. To capture game preview logs, your game code needs to send logs to the MCP server's `/log` endpoint.
+
+**Setup:**
+
+Add a console capture script to your game project:
+
+```typescript
+const MCP_LOG_URL = "http://127.0.0.1:3000/log";
+const FLUSH_INTERVAL = 500;
+
+let buffer: Array<{ timestamp: string; level: string; message: string }> = [];
+
+function hook(level: string, original: (...args: any[]) => void) {
+    return function (...args: any[]) {
+        original.apply(console, args);
+        buffer.push({
+            timestamp: new Date().toISOString(),
+            level,
+            message: args.map(a => typeof a === "string" ? a : JSON.stringify(a)).join(" "),
+        });
+    };
+}
+
+console.log = hook("log", console.log);
+console.warn = hook("warn", console.warn);
+console.error = hook("error", console.error);
+
+setInterval(() => {
+    if (buffer.length === 0) return;
+    const entries = buffer.splice(0, 50);
+    fetch(MCP_LOG_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(entries),
+    }).catch(() => {}); // silently ignore if MCP server is not running
+}, FLUSH_INTERVAL);
+```
+
+**`POST /log` format:**
+
+```json
+[
+  { "timestamp": "2026-03-26T12:00:00.000Z", "level": "log", "message": "Hello" },
+  { "timestamp": "2026-03-26T12:00:01.000Z", "level": "error", "message": "Something failed" }
+]
+```
+
+Both scene and game logs are merged chronologically when retrieved via `debug_get_console_logs`. Each log entry includes a `source` field (`"scene"` or `"game"`) to distinguish the origin.
+
 ## Configuration
 
 Settings are stored in `{project}/settings/cocos-creator-mcp.json`:
@@ -334,6 +393,7 @@ node test/regression.mjs 3001    # custom port
 - **v0.1** — MCP server + scene/node tools (13 tools)
 - **v0.5** — Component, prefab, project, debug tools (27 tools)
 - **v1.0** — Full tool coverage (145 tools, 13 categories, 224 test assertions)
+- **v1.1** — Console log capture (scene process auto-capture + game preview via `/log` endpoint)
 
 ## Development
 

--- a/source/mcp-server.ts
+++ b/source/mcp-server.ts
@@ -3,6 +3,30 @@ import { ToolCategory, ToolDefinition, JsonRpcRequest, JsonRpcResponse, ServerCo
 
 const MCP_PROTOCOL_VERSION = "2024-11-05";
 
+// ─── Game Preview Log Buffer ───
+
+interface GameLogEntry {
+    timestamp: string;
+    level: "log" | "warn" | "error";
+    message: string;
+}
+
+const MAX_GAME_LOG_BUFFER = 500;
+const _gameLogs: GameLogEntry[] = [];
+
+/** Access game preview log buffer from debug-tools */
+export function getGameLogs(count: number, level?: string): { logs: GameLogEntry[]; total: number } {
+    let logs = _gameLogs;
+    if (level) {
+        logs = logs.filter(l => l.level === level);
+    }
+    return { logs: logs.slice(-count), total: _gameLogs.length };
+}
+
+export function clearGameLogs(): void {
+    _gameLogs.length = 0;
+}
+
 export class McpServer {
     private server: http.Server | null = null;
     private tools: Map<string, ToolCategory> = new Map();
@@ -91,6 +115,27 @@ export class McpServer {
         if (url === "/health" && req.method === "GET") {
             res.writeHead(200, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ status: "ok", tools: this.getAllTools().length }));
+            return;
+        }
+
+        // Game preview log receiver
+        if (url === "/log" && req.method === "POST") {
+            const body = await readBody(req);
+            try {
+                const entries: GameLogEntry[] = JSON.parse(body);
+                for (const entry of (Array.isArray(entries) ? entries : [entries])) {
+                    _gameLogs.push({
+                        timestamp: entry.timestamp || new Date().toISOString(),
+                        level: entry.level || "log",
+                        message: entry.message || "",
+                    });
+                }
+                if (_gameLogs.length > MAX_GAME_LOG_BUFFER) {
+                    _gameLogs.splice(0, _gameLogs.length - MAX_GAME_LOG_BUFFER);
+                }
+            } catch { /* ignore malformed */ }
+            res.writeHead(204);
+            res.end();
             return;
         }
 

--- a/source/scene.ts
+++ b/source/scene.ts
@@ -7,6 +7,54 @@
 import { join } from "path";
 module.paths.push(join(Editor.App.path, "node_modules"));
 
+// ─── Console Log Buffer ───
+
+interface ConsoleLogEntry {
+    timestamp: string;
+    level: "log" | "warn" | "error";
+    message: string;
+}
+
+const MAX_LOG_BUFFER = 500;
+const _consoleLogs: ConsoleLogEntry[] = [];
+
+const _originalLog = console.log;
+const _originalWarn = console.warn;
+const _originalError = console.error;
+
+function formatArgs(args: any[]): string {
+    return args.map(a => {
+        if (typeof a === "string") return a;
+        try { return JSON.stringify(a); } catch { return String(a); }
+    }).join(" ");
+}
+
+function pushLog(level: ConsoleLogEntry["level"], args: any[]): void {
+    _consoleLogs.push({
+        timestamp: new Date().toISOString(),
+        level,
+        message: formatArgs(args),
+    });
+    if (_consoleLogs.length > MAX_LOG_BUFFER) {
+        _consoleLogs.splice(0, _consoleLogs.length - MAX_LOG_BUFFER);
+    }
+}
+
+console.log = function (...args: any[]) {
+    _originalLog.apply(console, args);
+    pushLog("log", args);
+};
+
+console.warn = function (...args: any[]) {
+    _originalWarn.apply(console, args);
+    pushLog("warn", args);
+};
+
+console.error = function (...args: any[]) {
+    _originalError.apply(console, args);
+    pushLog("error", args);
+};
+
 function getScene() {
     const { director } = require("cc");
     return director.getScene();
@@ -203,6 +251,24 @@ export const methods: Record<string, (...args: any[]) => any> = {
         } catch (e: any) {
             return { success: false, error: e.message };
         }
+    },
+
+    testLog(message: string = "test message") {
+        console.log("[testLog]", message);
+        return { success: true, bufferSize: _consoleLogs.length };
+    },
+
+    getConsoleLogs(count: number = 50, level?: string) {
+        let logs = _consoleLogs;
+        if (level) {
+            logs = logs.filter(l => l.level === level);
+        }
+        return { success: true, logs: logs.slice(-count), total: _consoleLogs.length };
+    },
+
+    clearConsoleLogs() {
+        _consoleLogs.length = 0;
+        return { success: true };
     },
 
     removeComponentFromNode(uuid: string, componentType: string) {

--- a/source/tools/debug-tools.ts
+++ b/source/tools/debug-tools.ts
@@ -1,5 +1,6 @@
 import { ToolCategory, ToolDefinition, ToolResult } from "../types";
 import { ok, err } from "../tool-base";
+import { getGameLogs, clearGameLogs } from "../mcp-server";
 
 export class DebugTools implements ToolCategory {
     readonly categoryName = "debug";
@@ -36,11 +37,12 @@ export class DebugTools implements ToolCategory {
             },
             {
                 name: "debug_get_console_logs",
-                description: "Get recent console log entries from the editor.",
+                description: "Get recent console log entries. Automatically captures scene process logs (console.log/warn/error in scene scripts). Game preview logs can also be captured by sending POST requests to /log endpoint — see README for setup.",
                 inputSchema: {
                     type: "object",
                     properties: {
                         count: { type: "number", description: "Max number of entries (default 50)" },
+                        level: { type: "string", description: "Filter by level: 'log', 'warn', or 'error'" },
                     },
                 },
             },
@@ -124,9 +126,17 @@ export class DebugTools implements ToolCategory {
                 case "debug_execute_script":
                     return this.executeScript(args.method, args.args || []);
                 case "debug_get_console_logs":
-                    return this.getConsoleLogs(args.count || 50);
+                    return this.getConsoleLogs(args.count || 50, args.level);
                 case "debug_clear_console":
                     Editor.Message.send("console", "clear");
+                    // Clear scene process log buffer
+                    await Editor.Message.request("scene", "execute-scene-script", {
+                        name: "cocos-creator-mcp",
+                        method: "clearConsoleLogs",
+                        args: [],
+                    }).catch(() => {});
+                    // Clear game preview log buffer
+                    clearGameLogs();
                     return ok({ success: true });
                 case "debug_list_extensions":
                     return this.listExtensions();
@@ -201,13 +211,37 @@ export class DebugTools implements ToolCategory {
         return ok(result);
     }
 
-    private async getConsoleLogs(_count: number): Promise<ToolResult> {
+    private async getConsoleLogs(count: number, level?: string): Promise<ToolResult> {
+        // Collect from both sources: scene process + game preview
+        let sceneLogs: any[] = [];
+        let gameLogs: any[] = [];
+
+        // 1. Scene process logs
         try {
-            const logs = await (Editor.Message.request as any)("console", "query-last-logs", _count);
-            return ok({ success: true, logs });
-        } catch {
-            return ok({ success: true, logs: [], note: "Console log query not supported in this editor version" });
-        }
+            const result = await Editor.Message.request("scene", "execute-scene-script", {
+                name: "cocos-creator-mcp",
+                method: "getConsoleLogs",
+                args: [count * 2, level], // request more, will trim after merge
+            });
+            if (result?.logs) {
+                sceneLogs = result.logs.map((l: any) => ({ ...l, source: "scene" }));
+            }
+        } catch { /* scene not available */ }
+
+        // 2. Game preview logs
+        const gameResult = getGameLogs(count * 2, level);
+        gameLogs = gameResult.logs.map((l: any) => ({ ...l, source: "game" }));
+
+        // Merge and sort by timestamp, take last `count`
+        const merged = [...sceneLogs, ...gameLogs]
+            .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+            .slice(-count);
+
+        return ok({
+            success: true,
+            logs: merged,
+            total: { scene: sceneLogs.length, game: gameResult.total },
+        });
     }
 
     private async listExtensions(): Promise<ToolResult> {

--- a/source/tools/debug-tools.ts
+++ b/source/tools/debug-tools.ts
@@ -212,11 +212,19 @@ export class DebugTools implements ToolCategory {
     }
 
     private async getConsoleLogs(count: number, level?: string): Promise<ToolResult> {
-        // Collect from both sources: scene process + game preview
+        // 1. Try Editor's native console API first (may be supported in future CocosCreator versions)
+        try {
+            const logs = await (Editor.Message.request as any)("console", "query-last-logs", count);
+            if (Array.isArray(logs) && logs.length > 0) {
+                return ok({ success: true, logs, source: "editor-api", note: "Using native Editor console API" });
+            }
+        } catch { /* Not supported in this version — use fallback */ }
+
+        // 2. Fallback: collect from scene process buffer + game preview buffer
         let sceneLogs: any[] = [];
         let gameLogs: any[] = [];
 
-        // 1. Scene process logs
+        // 2a. Scene process logs (console wrapper in scene.ts)
         try {
             const result = await Editor.Message.request("scene", "execute-scene-script", {
                 name: "cocos-creator-mcp",
@@ -228,7 +236,7 @@ export class DebugTools implements ToolCategory {
             }
         } catch { /* scene not available */ }
 
-        // 2. Game preview logs
+        // 2b. Game preview logs (received via POST /log endpoint)
         const gameResult = getGameLogs(count * 2, level);
         gameLogs = gameResult.logs.map((l: any) => ({ ...l, source: "game" }));
 


### PR DESCRIPTION
## Summary
- **コンソールログ取得** — scene自動キャプチャ + ゲームプレビュー対応（POST /log）
- **scene_save修正** — Editor.Message.sendでシーン保存が動作
- **エディタスクショ** — debug_screenshotでエディタウィンドウキャプチャ
- **Preview in Editor** — debug_previewでエディタ内プレビュー起動（scene:editor-preview-set-play）
- **キャッシュクリア** — debug_clear_code_cacheでElectronメニュー経由実行
- **ゲームコマンド** — debug_game_commandでゲームプレビューにコマンド送信（screenshot/click/navigate/state）
- **client/** — McpDebugClient・McpConsoleCapture汎用版（extensions/から直接import可能）

## AI自律開発で可能になったこと
| 操作 | ツール |
|------|--------|
| シーン保存 | scene_save |
| キャッシュクリア | debug_clear_code_cache |
| プレビュー起動 | debug_preview |
| ゲーム画面スクショ | debug_game_command screenshot |
| エディタ画面スクショ | debug_screenshot |
| コンソールログ | debug_get_console_logs |
| ゲーム操作 | debug_game_command click/navigate |

## Test plan
- [x] scene_saveでシーン保存が動作
- [x] debug_screenshotでエディタスクショ取得
- [x] debug_previewでPreview in Editor起動
- [x] debug_game_command screenshotでゲーム画面キャプチャ
- [x] debug_get_console_logsでゲームプレビューログ取得
- [x] client/から直接importして動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)