### PR TITLE
Preview Recorder: スクショボタン + UI整理 (v1.8.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,19 +475,6 @@ After building, reload the extension in Cocos Creator:
 - Cocos Creator 3.8+
 - Node.js 18+
 
-## Future Ideas (Preview Recorder)
-
-追加を検討している機能。現状の実装は「プロジェクトのネイティブ解像度で録画/スクショ」のシンプル構成だが、配布シナリオが増えたら対応したい。
-
-- **出力解像度プリセット (録画)**: YouTube投稿用 (1920x1080) 等、固定解像度にリサイズして書き出し。
-  canvas.captureStream の上流で OffscreenCanvas に縮小描画、または ffmpeg 後処理で対応。
-- **出力解像度プリセット (スクショ)**: App Store 納品用 (6.5" iPhone = 1242x2688 等) のサイズ指定。
-  既存の maxWidth と高さ指定を組み合わせる or アスペクト比指定リサイズ。
-- **動画フォーマット変換ユーティリティ**: WebM → MP4 を ffmpeg で変換するボタン。
-  （MediaRecorder の MP4 サポートはブラウザ依存のため、安定化のため WebM 録画 + 変換の選択肢）
-
-実装時は「プロジェクトに合うプリセット」の判断を使う側に委ねるため、プリセットセット自体をユーザー設定で定義できる形にすると汎用性が高い。
-
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ AI assistants like Claude can control Cocos Creator editor through this extensio
 - **JSON-RPC 2.0** — Standard MCP protocol compliance
 - **Prefab Property Persistence** — Component properties are correctly preserved when saving prefabs
 - **Preview in Editor** — Start editor preview programmatically (no manual button click needed)
-- **Screenshot Capture** — Capture editor window and game preview screenshots
-- **Game Command Control** — Send commands to running game preview (screenshot, click, navigate, state)
+- **Screenshot Capture** — Capture editor window and game preview screenshots (WebP / PNG)
+- **Video Recording** — Record game preview canvas to video (MP4 / WebM) via Preview Recorder panel
+- **Game Command Control** — Send commands to running game preview (screenshot, click, navigate, state, inspect)
 - **Client Scripts** — Drop-in TypeScript files for game preview integration (`client/`)
 - **Auto Start** — Server starts automatically when the extension loads
 - **Tool Call Logging** — All tool invocations logged with timing for debugging
 - **UUID Validation** — Input validation helpers for better error messages
 - **i18n** — English, Japanese, Chinese
-- **Regression Tests** — 224 assertions covering all 145 tools
+- **Regression Tests** — 265 assertions covering all 156 tools
 
 ## Quick Start
 
@@ -249,7 +250,7 @@ curl http://127.0.0.1:3000/health
 </details>
 
 <details>
-<summary><strong>Debug (17)</strong> — Editor info, logs, preview, screenshots, game control</summary>
+<summary><strong>Debug (21)</strong> — Editor info, logs, preview, screenshots, recording, game control</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -261,7 +262,11 @@ curl http://127.0.0.1:3000/health
 | `debug_preview` | Start Preview in Editor (play button) |
 | `debug_clear_code_cache` | Clear code cache (Developer > Cache) |
 | `debug_screenshot` | Capture editor window screenshot |
-| `debug_game_command` | Send command to game preview (screenshot/click/navigate/state) |
+| `debug_game_command` | Send command to game preview (screenshot/click/navigate/state/inspect) |
+| `debug_batch_screenshot` | Navigate to multiple pages and screenshot each |
+| `debug_record_start` | Start recording game preview canvas (webm/mp4) |
+| `debug_record_stop` | Stop recording and save video file |
+| `debug_reload_extension` | Reload this MCP extension (after build) |
 | `debug_list_extensions` | List installed extensions |
 | `debug_get_extension_info` | Get extension details |
 | `debug_get_project_logs` | Read project log entries |
@@ -446,6 +451,12 @@ node test/regression.mjs 3001    # custom port
 - **v1.0** — Full tool coverage (145 tools, 13 categories, 224 test assertions)
 - **v1.1** — Console log capture (scene process auto-capture + game preview via `/log` endpoint)
 - **v1.2** — AI autonomous development: Preview in Editor, screenshot capture, game command control, code cache clear, scene save fix. Client scripts for game preview integration (`client/`)
+- **v1.3** — `scene:set-property` for Prefab保存対応, prefab_create overwrite guard, param alias (`component` → `componentType`)
+- **v1.5** — `prefab_create_and_replace`, batch `set_property`, `prefab_open`
+- **v1.6** — `debug_batch_screenshot`, widget support in `create_tree`, `component_query_enum`, `server_check_code_sync`
+- **v1.8.0** — Preview Recorder panel: `debug_record_start` / `debug_record_stop` (MediaRecorder via canvas.captureStream, MP4/WebM, quality presets)
+- **v1.8.1** — Fix: `component_set_property` で cc.Asset 参照 (cc.Font 等) が type 未指定時に cc.Node にフォールバックされ破棄される問題を修正
+- **v1.8.2** — Preview Recorder: スクショボタン追加 (webp/png 切替, 最大幅指定), セクション分け UI
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -475,6 +475,19 @@ After building, reload the extension in Cocos Creator:
 - Cocos Creator 3.8+
 - Node.js 18+
 
+## Future Ideas (Preview Recorder)
+
+追加を検討している機能。現状の実装は「プロジェクトのネイティブ解像度で録画/スクショ」のシンプル構成だが、配布シナリオが増えたら対応したい。
+
+- **出力解像度プリセット (録画)**: YouTube投稿用 (1920x1080) 等、固定解像度にリサイズして書き出し。
+  canvas.captureStream の上流で OffscreenCanvas に縮小描画、または ffmpeg 後処理で対応。
+- **出力解像度プリセット (スクショ)**: App Store 納品用 (6.5" iPhone = 1242x2688 等) のサイズ指定。
+  既存の maxWidth と高さ指定を組み合わせる or アスペクト比指定リサイズ。
+- **動画フォーマット変換ユーティリティ**: WebM → MP4 を ffmpeg で変換するボタン。
+  （MediaRecorder の MP4 サポートはブラウザ依存のため、安定化のため WebM 録画 + 変換の選択肢）
+
+実装時は「プロジェクトに合うプリセット」の判断を使う側に委ねるため、プリセットセット自体をユーザー設定で定義できる形にすると汎用性が高い。
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
     "package_version": 2,
     "name": "cocos-creator-mcp",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "author": "harady",
     "editor": ">=3.8.0",
     "scripts": {
         "build": "tsc && node scripts/postbuild.js",
         "watch": "tsc -w"
     },
-    "description": "MCP Server for Cocos Creator [d997da23612a]",
+    "description": "MCP Server for Cocos Creator [1284b000d23f]",
     "main": "./dist/main.js",
     "dependencies": {
         "vue": "^3.1.4",

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -51,10 +51,6 @@ module.exports = Editor.Panel.define({
             <option value="webp">WebP</option>
             <option value="png">PNG</option>
         </select>
-        <label>最大幅:</label>
-        <input type="number" v-model.number="shotMaxWidth" :disabled="shooting" min="0" max="4096" step="100"
-               title="キャンバスをこの幅にリサイズ。0 で原寸のまま保存" />
-        <span class="unit">px (0=原寸)</span>
     </div>
 
     <div class="section-title">保存先</div>
@@ -142,7 +138,7 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
         if (!this.$.app) return;
         const MCP_BASE = "http://127.0.0.1:3000";
         const STORAGE_KEY = "cocos-mcp-recorder-settings";
-        const PERSISTED_KEYS = ["fps", "quality", "coefficient", "format", "savePath", "shotFormat", "shotMaxWidth"];
+        const PERSISTED_KEYS = ["fps", "quality", "coefficient", "format", "savePath", "shotFormat"];
         // localStorage から設定を読み込み
         const loadSettings = () => {
             try {
@@ -165,7 +161,6 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                     format: saved.format ?? "mp4",
                     savePath: saved.savePath ?? "temp/recordings",
                     shotFormat: saved.shotFormat ?? "png",
-                    shotMaxWidth: saved.shotMaxWidth ?? 0,
                     lastResult: null as any,
                     lastError: false,
                     _startTime: 0,
@@ -180,7 +175,6 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                 format(this: any) { this.saveSettings(); },
                 savePath(this: any) { this.saveSettings(); },
                 shotFormat(this: any) { this.saveSettings(); },
-                shotMaxWidth(this: any) { this.saveSettings(); },
             },
             methods: {
                 saveSettings(this: any) {
@@ -309,7 +303,7 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                                 method: "tools/call",
                                 params: {
                                     name: "debug_game_command",
-                                    arguments: { type: "screenshot", args: {}, timeout: 5000, maxWidth: this.shotMaxWidth, imageFormat: this.shotFormat },
+                                    arguments: { type: "screenshot", args: {}, timeout: 5000, maxWidth: 0, imageFormat: this.shotFormat },
                                 },
                             }),
                         });

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -41,7 +41,7 @@ module.exports = Editor.Panel.define({
         <input type="number" v-model.number="coefficient" @input="onCoefChange"
                :disabled="recording" min="0.01" max="2" step="0.01" class="custom-bitrate"
                title="ビットレート = 幅 × 高さ × FPS × 品質係数" />
-        <span class="unit" title="720x1280 canvas 換算の目安">≈ {{ estimatedMbps }} Mbps</span>
+        <span class="unit" :title="`${canvasWidth}x${canvasHeight} 換算の目安`">≈ {{ estimatedMbps }} Mbps @ {{ canvasWidth }}x{{ canvasHeight }}</span>
         <button @click="resetQuality" class="btn btn-small" :disabled="recording" title="録画設定を初期値に戻す">↺</button>
     </div>
 
@@ -152,6 +152,15 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
             } catch { return {}; }
         };
         const saved = loadSettings();
+        // プロジェクトの design resolution を取得 (失敗時は 720x1280 にフォールバック)
+        let canvasW = 720, canvasH = 1280;
+        try {
+            const dr = (Editor as any).Profile.getConfig("project", "general.designResolution");
+            if (dr && typeof dr.width === "number" && typeof dr.height === "number") {
+                canvasW = dr.width;
+                canvasH = dr.height;
+            }
+        } catch { /* ignore */ }
         const app = createAppRec({
             data() {
                 return {
@@ -160,6 +169,8 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                     shooting: false,
                     elapsed: "0.0",
                     recordingInfo: "",
+                    canvasWidth: canvasW,
+                    canvasHeight: canvasH,
                     fps: saved.fps ?? 30,
                     quality: saved.quality ?? "medium",
                     coefficient: saved.coefficient ?? 0.25,
@@ -175,9 +186,9 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                 };
             },
             computed: {
-                /** 720x1280 canvas 換算のビットレート目安 (Mbps) */
+                /** プロジェクトの design resolution を使ったビットレート目安 (Mbps) */
                 estimatedMbps(this: any): string {
-                    const bps = 720 * 1280 * this.fps * this.coefficient;
+                    const bps = this.canvasWidth * this.canvasHeight * this.fps * this.coefficient;
                     return (bps / 1_000_000).toFixed(1);
                 },
             },

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -18,6 +18,17 @@ module.exports = Editor.Panel.define({
         <span class="info">{{ recordingInfo }}</span>
     </div>
 
+    <div class="section-title">保存先</div>
+    <div class="row">
+        <input type="text" v-model="savePath" :disabled="recording" class="path-input" placeholder="temp/recordings" />
+        <button @click="selectSaveFolder" class="btn btn-small" :disabled="recording">📁 選択</button>
+        <button @click="resetSavePath" class="btn btn-small" :disabled="recording" title="保存先を初期値に戻す">↺</button>
+    </div>
+    <div class="row">
+        <button @click="openSaveFolder" class="btn btn-small">📂 保存フォルダを開く</button>
+    </div>
+
+    <div class="section-title">録画設定</div>
     <div class="row">
         <label>FPS:</label>
         <input type="number" v-model.number="fps" :disabled="recording" min="10" max="60" />
@@ -40,16 +51,6 @@ module.exports = Editor.Panel.define({
         <input type="number" v-model.number="coefficient" @input="onCoefChange"
                :disabled="recording" min="0.01" max="2" step="0.01" class="custom-bitrate" />
         <button @click="resetQuality" class="btn btn-small" :disabled="recording" title="録画設定を初期値に戻す">↺</button>
-    </div>
-
-    <div class="row">
-        <label>保存先:</label>
-        <input type="text" v-model="savePath" :disabled="recording" class="path-input" placeholder="temp/recordings" />
-        <button @click="selectSaveFolder" class="btn btn-small" :disabled="recording">📁 選択</button>
-        <button @click="resetSavePath" class="btn btn-small" :disabled="recording" title="保存先を初期値に戻す">↺</button>
-    </div>
-    <div class="row">
-        <button @click="openSaveFolder" class="btn btn-small">📂 保存フォルダを開く</button>
     </div>
 
     <div v-if="lastResult" class="result" :class="lastError ? 'error' : 'success'">
@@ -88,6 +89,15 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
 .btn-stop:hover { background: #999; }
 .btn-shot { background: #468; margin-left: 8px; }
 .btn-shot:hover { background: #579; }
+.section-title {
+    margin-top: 14px;
+    margin-bottom: 4px;
+    padding: 4px 0 3px 0;
+    font-size: 11px;
+    font-weight: bold;
+    color: #8af;
+    border-bottom: 1px solid #333;
+}
 .btn-small {
     padding: 4px 10px;
     background: #4a8;

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -18,28 +18,6 @@ module.exports = Editor.Panel.define({
         <span class="info">{{ recordingInfo }}</span>
     </div>
 
-    <div class="section-title">保存先</div>
-    <div class="row">
-        <input type="text" v-model="savePath" :disabled="recording" class="path-input" placeholder="temp/recordings" />
-        <button @click="selectSaveFolder" class="btn btn-small" :disabled="recording">📁 選択</button>
-        <button @click="resetSavePath" class="btn btn-small" :disabled="recording" title="保存先を初期値に戻す">↺</button>
-    </div>
-    <div class="row">
-        <button @click="openSaveFolder" class="btn btn-small">📂 保存フォルダを開く</button>
-    </div>
-
-    <div class="section-title">スクショ設定</div>
-    <div class="row">
-        <label>形式:</label>
-        <select v-model="shotFormat" :disabled="shooting">
-            <option value="webp">WebP</option>
-            <option value="png">PNG</option>
-        </select>
-        <label>最大幅:</label>
-        <input type="number" v-model.number="shotMaxWidth" :disabled="shooting" min="0" max="4096" step="100" title="0 = 原寸" />
-        <span class="unit">px (0=原寸)</span>
-    </div>
-
     <div class="section-title">録画設定</div>
     <div class="row">
         <label>FPS:</label>
@@ -63,6 +41,28 @@ module.exports = Editor.Panel.define({
         <input type="number" v-model.number="coefficient" @input="onCoefChange"
                :disabled="recording" min="0.01" max="2" step="0.01" class="custom-bitrate" />
         <button @click="resetQuality" class="btn btn-small" :disabled="recording" title="録画設定を初期値に戻す">↺</button>
+    </div>
+
+    <div class="section-title">スクショ設定</div>
+    <div class="row">
+        <label>形式:</label>
+        <select v-model="shotFormat" :disabled="shooting">
+            <option value="webp">WebP</option>
+            <option value="png">PNG</option>
+        </select>
+        <label>最大幅:</label>
+        <input type="number" v-model.number="shotMaxWidth" :disabled="shooting" min="0" max="4096" step="100" title="0 = 原寸" />
+        <span class="unit">px (0=原寸)</span>
+    </div>
+
+    <div class="section-title">保存先</div>
+    <div class="row">
+        <input type="text" v-model="savePath" :disabled="recording" class="path-input" placeholder="temp/recordings" />
+        <button @click="selectSaveFolder" class="btn btn-small" :disabled="recording">📁 選択</button>
+        <button @click="resetSavePath" class="btn btn-small" :disabled="recording" title="保存先を初期値に戻す">↺</button>
+    </div>
+    <div class="row">
+        <button @click="openSaveFolder" class="btn btn-small">📂 保存フォルダを開く</button>
     </div>
 
     <div v-if="lastResult" class="result" :class="lastError ? 'error' : 'success'">

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -10,6 +10,7 @@ module.exports = Editor.Panel.define({
     <div class="controls">
         <button v-if="!recording" @click="start" class="btn btn-start">● 録画開始</button>
         <button v-else @click="stop" class="btn btn-stop" :disabled="stopping">■ 録画停止{{ stopping ? '中...' : '' }}</button>
+        <button @click="screenshot" class="btn btn-shot" :disabled="shooting">📸 スクショ{{ shooting ? '中...' : '' }}</button>
     </div>
 
     <div v-if="recording" class="status-row">
@@ -53,9 +54,9 @@ module.exports = Editor.Panel.define({
 
     <div v-if="lastResult" class="result" :class="lastError ? 'error' : 'success'">
         <div v-if="!lastError">
-            <strong>✓ 録画完了</strong><br>
+            <strong>✓ {{ lastResult.kind === 'shot' ? 'スクショ保存' : '録画完了' }}</strong><br>
             <code>{{ lastResult.path }}</code><br>
-            {{ (lastResult.size / 1024 / 1024).toFixed(2) }} MB
+            {{ (lastResult.size / 1024).toFixed(1) }} KB
         </div>
         <div v-else>
             <strong>✗ エラー:</strong> {{ lastResult.error || lastResult.message || 'unknown' }}
@@ -85,6 +86,8 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
 .btn-start:hover { background: #e55; }
 .btn-stop { background: #888; }
 .btn-stop:hover { background: #999; }
+.btn-shot { background: #468; margin-left: 8px; }
+.btn-shot:hover { background: #579; }
 .btn-small {
     padding: 4px 10px;
     background: #4a8;
@@ -119,6 +122,7 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                 return {
                     recording: false,
                     stopping: false,
+                    shooting: false,
                     elapsed: "0.0",
                     recordingInfo: "",
                     fps: 30,
@@ -242,6 +246,51 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                 },
                 resetSavePath(this: any) {
                     this.savePath = "temp/recordings";
+                },
+                async screenshot(this: any) {
+                    this.shooting = true;
+                    try {
+                        const res = await fetch(`${MCP_BASE}/mcp`, {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({
+                                jsonrpc: "2.0",
+                                id: 3,
+                                method: "tools/call",
+                                params: {
+                                    name: "debug_game_command",
+                                    arguments: { type: "screenshot", args: {}, timeout: 5000, maxWidth: 0 },
+                                },
+                            }),
+                        });
+                        const json = await res.json();
+                        const content = json.result?.content?.[0]?.text;
+                        const parsed = content ? JSON.parse(content) : null;
+                        if (parsed?.success && parsed.path) {
+                            // savePath 配下にコピー
+                            const fs = require("fs");
+                            const path = require("path");
+                            const projectPath = Editor.Project.path;
+                            let destDir = this.savePath || "temp/recordings";
+                            if (!path.isAbsolute(destDir)) destDir = path.join(projectPath, destDir);
+                            if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
+                            const ts = new Date().toISOString().replace(/[:.]/g, "-");
+                            const ext = path.extname(parsed.path) || ".png";
+                            const destPath = path.join(destDir, `screenshot_${ts}${ext}`);
+                            fs.copyFileSync(parsed.path, destPath);
+                            this.lastResult = { kind: "shot", path: destPath, size: parsed.size };
+                            this.lastError = false;
+                        } else {
+                            const errDetail = parsed?.error || parsed?.message || "スクショ失敗";
+                            this.lastResult = { error: errDetail };
+                            this.lastError = true;
+                        }
+                    } catch (e: any) {
+                        this.lastResult = { error: `通信エラー: ${e.message}` };
+                        this.lastError = true;
+                    } finally {
+                        this.shooting = false;
+                    }
                 },
                 async checkPreviewAlive(this: any) {
                     if (!this.recording) return;

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -28,6 +28,18 @@ module.exports = Editor.Panel.define({
         <button @click="openSaveFolder" class="btn btn-small">📂 保存フォルダを開く</button>
     </div>
 
+    <div class="section-title">スクショ設定</div>
+    <div class="row">
+        <label>形式:</label>
+        <select v-model="shotFormat" :disabled="shooting">
+            <option value="webp">WebP</option>
+            <option value="png">PNG</option>
+        </select>
+        <label>最大幅:</label>
+        <input type="number" v-model.number="shotMaxWidth" :disabled="shooting" min="0" max="4096" step="100" title="0 = 原寸" />
+        <span class="unit">px (0=原寸)</span>
+    </div>
+
     <div class="section-title">録画設定</div>
     <div class="row">
         <label>FPS:</label>
@@ -140,6 +152,8 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                     coefficient: 0.25,
                     format: "mp4",
                     savePath: "temp/recordings",
+                    shotFormat: "webp",
+                    shotMaxWidth: 0,
                     lastResult: null as any,
                     lastError: false,
                     _startTime: 0,
@@ -269,7 +283,7 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                                 method: "tools/call",
                                 params: {
                                     name: "debug_game_command",
-                                    arguments: { type: "screenshot", args: {}, timeout: 5000, maxWidth: 0 },
+                                    arguments: { type: "screenshot", args: {}, timeout: 5000, maxWidth: this.shotMaxWidth, imageFormat: this.shotFormat },
                                 },
                             }),
                         });

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -164,7 +164,7 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                     coefficient: saved.coefficient ?? 0.25,
                     format: saved.format ?? "mp4",
                     savePath: saved.savePath ?? "temp/recordings",
-                    shotFormat: saved.shotFormat ?? "webp",
+                    shotFormat: saved.shotFormat ?? "png",
                     shotMaxWidth: saved.shotMaxWidth ?? 0,
                     lastResult: null as any,
                     lastError: false,

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -41,7 +41,6 @@ module.exports = Editor.Panel.define({
         <input type="number" v-model.number="coefficient" @input="onCoefChange"
                :disabled="recording" min="0.01" max="2" step="0.01" class="custom-bitrate"
                title="ビットレート = 幅 × 高さ × FPS × 品質係数" />
-        <span class="unit" :title="`${canvasWidth}x${canvasHeight} 換算の目安`">≈ {{ estimatedMbps }} Mbps @ {{ canvasWidth }}x{{ canvasHeight }}</span>
         <button @click="resetQuality" class="btn btn-small" :disabled="recording" title="録画設定を初期値に戻す">↺</button>
     </div>
 
@@ -152,15 +151,6 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
             } catch { return {}; }
         };
         const saved = loadSettings();
-        // プロジェクトの design resolution を取得 (失敗時は 720x1280 にフォールバック)
-        let canvasW = 720, canvasH = 1280;
-        try {
-            const dr = (Editor as any).Profile.getConfig("project", "general.designResolution");
-            if (dr && typeof dr.width === "number" && typeof dr.height === "number") {
-                canvasW = dr.width;
-                canvasH = dr.height;
-            }
-        } catch { /* ignore */ }
         const app = createAppRec({
             data() {
                 return {
@@ -169,8 +159,6 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                     shooting: false,
                     elapsed: "0.0",
                     recordingInfo: "",
-                    canvasWidth: canvasW,
-                    canvasHeight: canvasH,
                     fps: saved.fps ?? 30,
                     quality: saved.quality ?? "medium",
                     coefficient: saved.coefficient ?? 0.25,
@@ -184,13 +172,6 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                     _timer: null as any,
                     _aliveCheckTimer: null as any,
                 };
-            },
-            computed: {
-                /** プロジェクトの design resolution を使ったビットレート目安 (Mbps) */
-                estimatedMbps(this: any): string {
-                    const bps = this.canvasWidth * this.canvasHeight * this.fps * this.coefficient;
-                    return (bps / 1_000_000).toFixed(1);
-                },
             },
             watch: {
                 fps(this: any) { this.saveSettings(); },

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -48,8 +48,8 @@ module.exports = Editor.Panel.define({
     <div class="row">
         <label>形式:</label>
         <select v-model="shotFormat" :disabled="shooting">
-            <option value="webp">WebP</option>
             <option value="png">PNG</option>
+            <option value="webp">WebP</option>
         </select>
     </div>
 

--- a/source/panels/recorder/index.ts
+++ b/source/panels/recorder/index.ts
@@ -37,9 +37,11 @@ module.exports = Editor.Panel.define({
             <option value="ultra">最高</option>
             <option value="custom">カスタム</option>
         </select>
-        <label>係数:</label>
+        <label title="ビットレート = 幅 × 高さ × FPS × 品質係数">品質係数:</label>
         <input type="number" v-model.number="coefficient" @input="onCoefChange"
-               :disabled="recording" min="0.01" max="2" step="0.01" class="custom-bitrate" />
+               :disabled="recording" min="0.01" max="2" step="0.01" class="custom-bitrate"
+               title="ビットレート = 幅 × 高さ × FPS × 品質係数" />
+        <span class="unit" title="720x1280 canvas 換算の目安">≈ {{ estimatedMbps }} Mbps</span>
         <button @click="resetQuality" class="btn btn-small" :disabled="recording" title="録画設定を初期値に戻す">↺</button>
     </div>
 
@@ -51,7 +53,8 @@ module.exports = Editor.Panel.define({
             <option value="png">PNG</option>
         </select>
         <label>最大幅:</label>
-        <input type="number" v-model.number="shotMaxWidth" :disabled="shooting" min="0" max="4096" step="100" title="0 = 原寸" />
+        <input type="number" v-model.number="shotMaxWidth" :disabled="shooting" min="0" max="4096" step="100"
+               title="キャンバスをこの幅にリサイズ。0 で原寸のまま保存" />
         <span class="unit">px (0=原寸)</span>
     </div>
 
@@ -139,6 +142,16 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
     ready() {
         if (!this.$.app) return;
         const MCP_BASE = "http://127.0.0.1:3000";
+        const STORAGE_KEY = "cocos-mcp-recorder-settings";
+        const PERSISTED_KEYS = ["fps", "quality", "coefficient", "format", "savePath", "shotFormat", "shotMaxWidth"];
+        // localStorage から設定を読み込み
+        const loadSettings = () => {
+            try {
+                const raw = localStorage.getItem(STORAGE_KEY);
+                return raw ? JSON.parse(raw) : {};
+            } catch { return {}; }
+        };
+        const saved = loadSettings();
         const app = createAppRec({
             data() {
                 return {
@@ -147,13 +160,13 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                     shooting: false,
                     elapsed: "0.0",
                     recordingInfo: "",
-                    fps: 30,
-                    quality: "medium",
-                    coefficient: 0.25,
-                    format: "mp4",
-                    savePath: "temp/recordings",
-                    shotFormat: "webp",
-                    shotMaxWidth: 0,
+                    fps: saved.fps ?? 30,
+                    quality: saved.quality ?? "medium",
+                    coefficient: saved.coefficient ?? 0.25,
+                    format: saved.format ?? "mp4",
+                    savePath: saved.savePath ?? "temp/recordings",
+                    shotFormat: saved.shotFormat ?? "webp",
+                    shotMaxWidth: saved.shotMaxWidth ?? 0,
                     lastResult: null as any,
                     lastError: false,
                     _startTime: 0,
@@ -161,7 +174,28 @@ h2 { margin: 0 0 12px 0; font-size: 18px; }
                     _aliveCheckTimer: null as any,
                 };
             },
+            computed: {
+                /** 720x1280 canvas 換算のビットレート目安 (Mbps) */
+                estimatedMbps(this: any): string {
+                    const bps = 720 * 1280 * this.fps * this.coefficient;
+                    return (bps / 1_000_000).toFixed(1);
+                },
+            },
+            watch: {
+                fps(this: any) { this.saveSettings(); },
+                quality(this: any) { this.saveSettings(); },
+                coefficient(this: any) { this.saveSettings(); },
+                format(this: any) { this.saveSettings(); },
+                savePath(this: any) { this.saveSettings(); },
+                shotFormat(this: any) { this.saveSettings(); },
+                shotMaxWidth(this: any) { this.saveSettings(); },
+            },
             methods: {
+                saveSettings(this: any) {
+                    const data: any = {};
+                    for (const key of PERSISTED_KEYS) data[key] = this[key];
+                    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); } catch { /* ignore */ }
+                },
                 async start(this: any) {
                     this.lastResult = null;
                     try {

--- a/source/tools/debug-tools.ts
+++ b/source/tools/debug-tools.ts
@@ -113,6 +113,7 @@ export class DebugTools implements ToolCategory {
                         args: { description: "Command arguments (e.g. {page: 'HomePageView'} for navigate, {name: 'ButtonName'} for click)" },
                         timeout: { type: "number", description: "Max wait time in ms (default 5000)" },
                         maxWidth: { type: "number", description: "Max width for screenshot resize (default: 960, 0 = no resize)" },
+                        imageFormat: { type: "string", description: "Screenshot output format: 'webp' (default, Q=85) or 'png' (lossless)" },
                     },
                     required: ["type"],
                 },
@@ -244,7 +245,7 @@ export class DebugTools implements ToolCategory {
                     await (Editor.Message.request as any)("program", "open-url", args.url);
                     return ok({ success: true, url: args.url });
                 case "debug_game_command":
-                    return this.gameCommand(args.type || args.command, args.args, args.timeout || 5000, args.maxWidth);
+                    return this.gameCommand(args.type || args.command, args.args, args.timeout || 5000, args.maxWidth, args.imageFormat);
                 case "debug_screenshot":
                     return this.takeScreenshot(args.savePath, args.maxWidth);
                 case "debug_preview":
@@ -581,7 +582,7 @@ export class DebugTools implements ToolCategory {
         }
     }
 
-    private async gameCommand(type: string, args: any, timeout: number, maxWidth?: number): Promise<ToolResult> {
+    private async gameCommand(type: string, args: any, timeout: number, maxWidth?: number, imageFormat?: string): Promise<ToolResult> {
         const cmdId = queueGameCommand(type, args);
 
         // Poll for result
@@ -603,7 +604,7 @@ export class DebugTools implements ToolCategory {
                         const electron = require("electron");
                         const origImage = electron.nativeImage.createFromBuffer(pngBuffer);
                         const originalSize = origImage.getSize();
-                        const { buffer, width, height, format } = await this.processImage(pngBuffer, effectiveMaxWidth);
+                        const { buffer, width, height, format } = await this.processImage(pngBuffer, effectiveMaxWidth, imageFormat);
                         const ext = format === "webp" ? "webp" : format === "jpeg" ? "jpg" : "png";
                         const filePath = path.join(dir, `game_${timestamp}.${ext}`);
                         fs.writeFileSync(filePath, buffer);
@@ -623,7 +624,7 @@ export class DebugTools implements ToolCategory {
         return err(`Game did not respond within ${timeout}ms. Is GameDebugClient running in the preview?`);
     }
 
-    private async processImage(pngBuffer: Buffer, maxWidth: number): Promise<{ buffer: Buffer; width: number; height: number; format: string }> {
+    private async processImage(pngBuffer: Buffer, maxWidth: number, desiredFormat?: string): Promise<{ buffer: Buffer; width: number; height: number; format: string }> {
         try {
             const Vips = require("wasm-vips");
             const vips = await Vips();
@@ -632,6 +633,13 @@ export class DebugTools implements ToolCategory {
             const origH = image.height;
             if (maxWidth > 0 && origW > maxWidth) {
                 image = image.thumbnailImage(maxWidth);
+            }
+            // png 明示指定時は pngsave (lossless)、それ以外は webp(Q=85)
+            if (desiredFormat === "png") {
+                const pngOut = image.pngsaveBuffer();
+                const result = { buffer: Buffer.from(pngOut), width: image.width, height: image.height, format: "png" };
+                image.delete();
+                return result;
             }
             const outBuf = image.webpsaveBuffer({ Q: 85 });
             const result = { buffer: Buffer.from(outBuf), width: image.width, height: image.height, format: "webp" };

--- a/source/tools/server-tools.ts
+++ b/source/tools/server-tools.ts
@@ -99,7 +99,12 @@ export class ServerTools implements ToolCategory {
                             return files;
                         };
                         for (const file of collectJs(extDir).sort()) {
-                            const content = fs.readFileSync(path.join(extDir, file), "utf8");
+                            let content = fs.readFileSync(path.join(extDir, file), "utf8");
+                            // mcp-server.js の baked hash を postbuild 前と同じプレースホルダに逆置換
+                            // (postbuild は __BUILD_HASH__ が残った状態でハッシュ計算しているため、同じ入力にする)
+                            if (file === "mcp-server.js") {
+                                content = content.replace(/exports\.BUILD_HASH = "[a-f0-9]{12}"/, 'exports.BUILD_HASH = "__BUILD_HASH__"');
+                            }
                             hash.update(content.replace(/__BUILD_HASH__/g, ""));
                         }
                         const diskHash = hash.digest("hex").substring(0, 12);


### PR DESCRIPTION
## 概要

Preview Recorder パネルに 📸 スクショボタンを追加し、あわせて UI 整理と設定の永続化を行った。

## 変更内容

### 📸 スクショ機能
- `btn-shot` ボタンを controls 行に追加（録画中でも押せる）
- `debug_game_command` (type=screenshot) を使ってゲームキャンバスをキャプチャ
- 結果を `savePath/screenshot_<ISO-timestamp>.png` にコピー
- 結果表示は `lastResult.kind` で「スクショ保存」/「録画完了」を切り替え
- サイズ表示を MB→KB に変更（スクショは小さいため）

### 出力フォーマット指定
- `debug_game_command` に `imageFormat` パラメータを追加 (webp/png)
- `processImage` に `desiredFormat="png"` を渡すと `pngsaveBuffer()` で lossless 出力
- パネルに形式セレクタ (WebP / PNG, 既定 **png**) を追加

### UI 整理
- 設定項目を 3 セクションに分離:
  1. **録画設定** (FPS/形式/品質/品質係数) ← パネルのメイン機能、変更頻度高
  2. **スクショ設定** (形式)
  3. **保存先** (savePath + フォルダボタン) ← set-and-forget
- 「係数」→「品質係数」にリネーム、tooltip で式を明示 (bitrate = 幅 × 高さ × FPS × 品質係数)
- 録画(webm↔mp4) とスクショ(webp↔png) の UX 対称性を維持するため、スクショ側のmaxWidth設定は削除

### 設定永続化
- localStorage で以下を保存: fps / quality / coefficient / format / savePath / shotFormat
- パネル再オープン時に前回値を復元

### README 更新
- Debug tools 17→21 (`debug_batch_screenshot`, `debug_reload_extension`, `debug_record_start`, `debug_record_stop`)
- Features に Video Recording を追記
- Version History に v1.3〜v1.8.2 を追記
- 総ツール数 145→156, 回帰テスト 224→265

## 前提
- ゲームプレビュー実行中に使う（GameDebugClient が必要）

## Test plan
- [x] プレビュー起動 → 📸 スクショ押下 → savePath 配下に png が保存される
- [x] 形式を WebP に切替 → webp が保存される
- [x] 録画中にもスクショ押せる
- [x] プレビュー停止中は通信エラーメッセージが出る
- [x] パネル閉じて開き直すと設定が保持される
- [x] 回帰テスト 265件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)