### PR TITLE
debug_game_command: args が JSON 文字列として渡される場合の対応 (v1.8.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
     "package_version": 2,
     "name": "cocos-creator-mcp",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "author": "harady",
     "editor": ">=3.8.0",
     "scripts": {
         "build": "tsc && node scripts/postbuild.js",
         "watch": "tsc -w"
     },
-    "description": "MCP Server for Cocos Creator [1284b000d23f]",
+    "description": "MCP Server for Cocos Creator [d48a0098de71]",
     "main": "./dist/main.js",
     "dependencies": {
         "vue": "^3.1.4",

--- a/source/tools/debug-tools.ts
+++ b/source/tools/debug-tools.ts
@@ -110,7 +110,7 @@ export class DebugTools implements ToolCategory {
                     type: "object",
                     properties: {
                         type: { type: "string", description: "Command type: 'screenshot', 'state', 'navigate', 'click', 'inspect'" },
-                        args: { description: "Command arguments (e.g. {page: 'HomePageView'} for navigate, {name: 'ButtonName'} for click)" },
+                        args: { type: "object", description: "Command arguments (e.g. {page: 'HomePageView'} for navigate, {name: 'ButtonName'} for click)" },
                         timeout: { type: "number", description: "Max wait time in ms (default 5000)" },
                         maxWidth: { type: "number", description: "Max width for screenshot resize (default: 960, 0 = no resize)" },
                         imageFormat: { type: "string", description: "Screenshot output format: 'webp' (default, Q=85) or 'png' (lossless)" },
@@ -244,8 +244,14 @@ export class DebugTools implements ToolCategory {
                 case "debug_open_url":
                     await (Editor.Message.request as any)("program", "open-url", args.url);
                     return ok({ success: true, url: args.url });
-                case "debug_game_command":
-                    return this.gameCommand(args.type || args.command, args.args, args.timeout || 5000, args.maxWidth, args.imageFormat);
+                case "debug_game_command": {
+                    // args.args は MCP クライアントによってはJSON文字列で来るためパースして吸収
+                    let innerArgs = args.args;
+                    if (typeof innerArgs === "string") {
+                        try { innerArgs = JSON.parse(innerArgs); } catch { /* string のまま */ }
+                    }
+                    return this.gameCommand(args.type || args.command, innerArgs, args.timeout || 5000, args.maxWidth, args.imageFormat);
+                }
                 case "debug_screenshot":
                     return this.takeScreenshot(args.savePath, args.maxWidth);
                 case "debug_preview":


### PR DESCRIPTION
## 概要

`debug_game_command` のネストした `args` プロパティが MCP クライアントによって JSON 文字列で送られてくるケースで、ゲーム側 `cmd.args?.name` 等が undefined になっていたバグを修正。

## 再現条件

Claude Code の MCP クライアントから以下のように呼ぶと発生した:

```json
{
  "type": "click",
  "args": { "name": "OkButton" }
}
```

サーバー側に届く時点で `args.args` が `'{"name":"OkButton"}'` (文字列) になっており、 `cmd.args?.name` は undefined。結果として "name argument required" エラー等が発生していた。

## 原因

tool schema で `args` プロパティに `type` が宣言されていなかったため、一部の MCP クライアントがネストオブジェクトを JSON 文字列化して送信していた。

## 修正内容

1. **schema 修正**: `args: { type: "object", ... }` を明示
2. **防御的パース**: `args.args` が string の場合は `JSON.parse` を試みる (schema 修正が効かないクライアント互換のため)

## Test plan

- [x] Claude Code から `debug_game_command({type:"click", args:{name:"TitlePageView"}})` → click 成功
- [x] `debug_game_command({type:"navigate", args:{page:"HomePageView"}})` → navigate 成功
- [x] `debug_game_command({type:"inspect", args:{name:"Canvas"}})` → Canvas ノード情報取得

すべて Claude Code 経由で動作確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)