### PR TITLE
scene_create: 3.8.x 非対応時のエラーメッセージ改善 (v1.8.4) (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,10 @@ After building, reload the extension in Cocos Creator:
 - Cocos Creator 3.8+
 - Node.js 18+
 
+## Known Limitations
+
+- **`scene_create`**: Does not work on Cocos Creator 3.8.x because the underlying `scene:new-scene` Editor message is not exposed on that version. As a workaround, create the `.scene` JSON file directly under `db://assets/` and call `project_refresh_assets` so the editor picks it up. See [#13](https://github.com/harady/cocos-creator-mcp/issues/13) for details.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
     "package_version": 2,
     "name": "cocos-creator-mcp",
-    "version": "1.8.3",
+    "version": "1.8.4",
     "author": "harady",
     "editor": ">=3.8.0",
     "scripts": {
         "build": "tsc && node scripts/postbuild.js",
         "watch": "tsc -w"
     },
-    "description": "MCP Server for Cocos Creator [d48a0098de71]",
+    "description": "MCP Server for Cocos Creator [f9b92f3a1427]",
     "main": "./dist/main.js",
     "dependencies": {
         "vue": "^3.1.4",

--- a/source/tools/scene-advanced-tools.ts
+++ b/source/tools/scene-advanced-tools.ts
@@ -303,8 +303,23 @@ export class SceneAdvancedTools implements ToolCategory {
                     return ok({ success: true, result });
                 }
                 case "scene_create":
-                    await (Editor.Message.request as any)("scene", "new-scene");
-                    return ok({ success: true });
+                    try {
+                        await (Editor.Message.request as any)("scene", "new-scene");
+                        return ok({ success: true });
+                    } catch (e: any) {
+                        const msg = e?.message || String(e);
+                        // Cocos Creator 3.8.x does not expose the scene:new-scene message
+                        if (msg.includes("Message does not exist") || msg.includes("scene - new-scene")) {
+                            return err(
+                                "scene_create is not supported on this Cocos Creator version " +
+                                "(scene:new-scene message is unavailable). " +
+                                "Workaround: write a .scene JSON file directly to db://assets/ and " +
+                                "call project_refresh_assets to let the editor pick it up. " +
+                                "See: https://github.com/harady/cocos-creator-mcp/issues/13",
+                            );
+                        }
+                        return err(msg);
+                    }
                 case "scene_cut_node":
                     await (Editor.Message.request as any)("scene", "cut-node", args.uuid);
                     return ok({ success: true, uuid: args.uuid });


### PR DESCRIPTION
## 概要

[#13](https://github.com/harady/cocos-creator-mcp/issues/13) への部分対応。`scene_create` ツールが Cocos Creator 3.8.x で動作しない件について、エラーメッセージを改善し、README に既知の制約を明記する。

## 変更内容

### 1. `scene_create` のエラーハンドリング改善

`Editor.Message.request("scene", "new-scene")` が失敗した際、"Message does not exist" を捕捉して分かりやすいエラーメッセージに置き換える:

- どのような状態か (scene:new-scene が未公開であること)
- ワークアラウンド (.scene JSON を直接書いて project_refresh_assets を呼ぶ)
- Issue #13 へのリンク

### 2. README に Known Limitations セクションを追加

`scene_create` が 3.8.x で動作しないことと、ワークアラウンドを明記。

## 本 PR の位置づけ

**完全な修正ではなく、部分対応**です:
- [x] エラーメッセージ改善
- [x] ドキュメント追記
- [ ] fallback 実装 (.scene JSON を直接書き出すアプローチ) ← 別対応

Issue #13 は本質的な修正 (fallback) が完了するまで open のまま維持します。

## Test plan

- [x] Cocos Creator 3.8.8 で `scene_create` を呼び出す
- [x] "Message does not exist" 由来の raw error ではなく、改善されたエラーメッセージが返る
- [x] エラーメッセージに issue #13 へのリンクが含まれる

実行結果:
```
scene_create is not supported on this Cocos Creator version (scene:new-scene message is unavailable). Workaround: write a .scene JSON file directly to db://assets/ and call project_refresh_assets to let the editor pick it up. See: https://github.com/harady/cocos-creator-mcp/issues/13
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)