### PR TITLE
docs: Known Limitations に prefab_create_from_spec の asset ref 問題を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,19 @@ After building, reload the extension in Cocos Creator:
 
 - **`scene_create`**: Does not work on Cocos Creator 3.8.x because the underlying `scene:new-scene` Editor message is not exposed on that version. As a workaround, create the `.scene` JSON file directly under `db://assets/` and call `project_refresh_assets` so the editor picks it up. See [#13](https://github.com/harady/cocos-creator-mcp/issues/13) for details.
 
+- **`prefab_create_from_spec` — asset refs are saved as raw UUID strings**:
+  When the spec's `properties` contains asset references like `cc.Sprite.spriteFrame` or `cc.Prefab` fields, they are serialized to the generated `.prefab` as raw UUID strings instead of the required `{__uuid__, __expectedType__}` object form. The Cocos runtime fails to resolve them (e.g. `Simple.updateUVs` throws every frame for a Sprite with unresolved spriteFrame). Workaround: post-process the generated `.prefab` files to wrap asset refs.
+
+  Example fix script:
+  ```js
+  // fix-prefab-asset-refs.js — run after prefab_create_from_spec
+  const re = /"_spriteFrame":\s*"([a-f0-9\-]+(?:@[a-z0-9]+)?)"/g;
+  content = content.replace(re, (_, uuid) =>
+    `"_spriteFrame": { "__uuid__": "${uuid}", "__expectedType__": "cc.SpriteFrame" }`
+  );
+  ```
+  The same pattern also applies when setting `cc.Prefab` fields via `component_set_property` — the value object form is ignored and the raw UUID is written. Direct `.prefab` JSON edit is the reliable workaround until fixed.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- `prefab_create_from_spec` で spec の `properties` に asset 参照（`cc.Sprite.spriteFrame` や `cc.Prefab` 型フィールド）を含めると、生成 `.prefab` に **raw UUID 文字列** で書き込まれる問題を Known Limitations に追加
- Cocos ランタイムはこの形式を asset として解決できず、Sprite なら `Simple.updateUVs` で毎フレーム例外が飛ぶ
- 正しい形式は `{__uuid__, __expectedType__}` オブジェクト形式
- ワークアラウンドとして post-process スクリプト例を README に掲載

## Background

SSDebugger 拡張機能の Prefab 群を MCP 経由で作成した際に発見。全 7 個の Prefab で Sprite の spriteFrame 参照が壊れており、APK/Web いずれも起動できなかった。同様に root Prefab からの `cc.Prefab` 型参照（パーツ Prefab の `@property`）も影響を受けた。

## Changes

- `README.md` の Known Limitations セクションに項目追加
- 回避策コード（`_spriteFrame` を regex で `{__uuid__, __expectedType__}` 形式に変換）を掲載

## Next

- 本体修正（`prefab_create_from_spec` 内部で asset refs を自動で正しい形式に書き出す）は別 PR で対応予定