### PR TITLE
fix: scene creation and encoded resource UUIDs on Creator 3.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,18 @@ Settings are stored in `{project}/settings/cocos-creator-mcp.json`:
 
 ## Testing
 
+Scene creation and resource URI compatibility checks (no running editor required):
+
+```bash
+npm run build
+node test/scene-create-compat.cjs
+node test/resource-uri-compat.cjs
+```
+
+These checks also run with the Node 14.16 runtime embedded in Creator 3.8.3.
+For resource templates, percent-encode UUID values (for example,
+`cocos://node/${encodeURIComponent(uuid)}/components`): Cocos short UUIDs can contain `/` and `+`.
+
 ```bash
 node test/regression.mjs         # default port 3000
 node test/regression.mjs 3001    # custom port
@@ -387,7 +399,7 @@ After building, reload the extension in Cocos Creator:
 ## Requirements
 
 - Cocos Creator 3.8+
-- Node.js 18+
+- Node.js 18+ for building the extension and running the HTTP regression client. The installed extension runs inside Creator's embedded Node runtime (including Node 14.16 in Creator 3.8.3).
 
 ## Value Reference Forms (v2.0.0)
 
@@ -440,7 +452,7 @@ These also work inside `prefab_create_from_spec`'s `spec.properties` because the
 
 ## Known Limitations
 
-- **`scene_create`**: Does not work on Cocos Creator 3.8.x because the underlying `scene:new-scene` Editor message is not exposed on that version. As a workaround, create the `.scene` JSON file directly under `db://assets/` and call `project_refresh_assets` so the editor picks it up. See [#13](https://github.com/harady/cocos-creator-mcp/issues/13) for details.
+- **`scene_create`**: On Creator 3.8.x, where `scene:new-scene` is unavailable, the tool creates a minimal 2D scene through the asset database. Both explicit paths and the automatically generated path are supported. The tool verifies that the created scene opened successfully; a failed open returns an error while leaving the created asset available for inspection. See [#13](https://github.com/harady/cocos-creator-mcp/issues/13) for background.
 
 - ~~**`prefab_create_from_spec` — asset refs are saved as raw UUID strings**~~ **(fixed in v2.0.0)** — Properties in `spec.properties` are now reapplied via the Editor API (`component_set_property`) after `buildNodeTree` completes, so asset refs serialize as `{__uuid__, __expectedType__}` correctly. The old workaround of post-processing `.prefab` files is no longer needed.
 

--- a/source/resources/registry.ts
+++ b/source/resources/registry.ts
@@ -51,7 +51,19 @@ export class ResourceRegistry {
             if (d.uriTemplate) {
                 const re = uriTemplateToRegExp(d.uriTemplate);
                 const m = re.exec(uri);
-                if (m) return { def: d, params: m.groups ? { ...m.groups } : {} };
+                if (m) {
+                    const params: Record<string, string> = {};
+                    try {
+                        for (const [key, value] of Object.entries(m.groups || {})) {
+                            // Cocos short UUIDs may contain '/' and '+'. Clients
+                            // percent-encode template values to keep them in one segment.
+                            params[key] = decodeURIComponent(value);
+                        }
+                    } catch {
+                        return null; // Invalid percent encoding is not a valid resource URI.
+                    }
+                    return { def: d, params };
+                }
             }
         }
         return null;

--- a/source/tools/scene-advanced-tools.ts
+++ b/source/tools/scene-advanced-tools.ts
@@ -1,6 +1,7 @@
 import { ToolCategory, ToolDefinition, ToolResult } from "../types";
 import { ok, err } from "../tool-base";
 import { ensureSceneSafeToSwitch } from "./scene-tools";
+import { randomBytes } from "crypto";
 
 const EXT_NAME = "cocos-creator-mcp";
 
@@ -348,7 +349,15 @@ export class SceneAdvancedTools implements ToolCategory {
             if (!path.endsWith(".scene")) path += ".scene";
 
             const sceneName = path.split("/").pop()!.replace(".scene", "");
-            const uid = () => crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+            // Creator 3.8.3 embeds Node 14.16: neither global crypto nor
+            // crypto.randomUUID is available. Generate an RFC 4122 v4 UUID.
+            const uid = () => {
+                const bytes = randomBytes(16);
+                bytes[6] = (bytes[6] & 0x0f) | 0x40;
+                bytes[8] = (bytes[8] & 0x3f) | 0x80;
+                const hex = bytes.toString("hex");
+                return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+            };
             const sid = () => {
                 const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
                 let s = "";
@@ -361,14 +370,15 @@ export class SceneAdvancedTools implements ToolCategory {
 
             await (Editor.Message.request as any)("asset-db", "create-asset", path, content);
 
-            // シーンを開く
-            try {
-                // ensureSceneSafeToSwitch は createScene 入口で既に通過済みなのでここでは再チェックしない
-                const queryResult = await (Editor.Message.request as any)("asset-db", "query-uuid", path);
-                if (queryResult) {
-                    await (Editor.Message.request as any)("scene", "open-scene", queryResult);
-                }
-            } catch { /* open failure is not critical */ }
+            // Verify that the created asset actually opened: some editor versions
+            // log a load error and switch to an empty scene without rejecting.
+            const queryResult = await (Editor.Message.request as any)("asset-db", "query-uuid", path);
+            if (!queryResult) throw new Error(`Created scene has no asset UUID: ${path}`);
+            await (Editor.Message.request as any)("scene", "open-scene", queryResult);
+            const current = await (Editor.Message.request as any)("scene", "query-node-tree");
+            if (current?.uuid !== queryResult) {
+                throw new Error(`Scene asset was created but could not be opened: ${path}`);
+            }
 
             return ok({ success: true, path, method: "asset-db-fallback" });
         } catch (e: any) {
@@ -412,7 +422,7 @@ export class SceneAdvancedTools implements ToolCategory {
                 _layer: 1073741824,
                 _euler: vec3(0, 0, 0),
                 autoReleaseAssets: false,
-                _globals: { __id__: 10 },
+                _globals: { __id__: 8 },
                 _id: sceneId,
             },
             // [2] Canvas node
@@ -522,23 +532,21 @@ export class SceneAdvancedTools implements ToolCategory {
                 _originalHeight: 0,
                 _id: "",
             },
-            // [8] cc.PrefabInfo for scene
-            // [9] (reserved)
-            // [10] SceneGlobals
+            // [8] SceneGlobals
             {
                 __type__: "cc.SceneGlobals",
-                ambient: { __id__: 11 },
-                shadows: { __id__: 12 },
-                _skybox: { __id__: 13 },
-                fog: { __id__: 14 },
+                ambient: { __id__: 9 },
+                shadows: { __id__: 10 },
+                _skybox: { __id__: 11 },
+                fog: { __id__: 12 },
             },
-            // [11] AmbientInfo
+            // [9] AmbientInfo
             { __type__: "cc.AmbientInfo", _skyLightingColor: { __type__: "cc.Vec4", x: 0.2, y: 0.2, z: 0.2, w: 1 } },
-            // [12] ShadowsInfo
+            // [10] ShadowsInfo
             { __type__: "cc.ShadowsInfo" },
-            // [13] SkyboxInfo
+            // [11] SkyboxInfo
             { __type__: "cc.SkyboxInfo" },
-            // [14] FogInfo
+            // [12] FogInfo
             { __type__: "cc.FogInfo" },
         ];
     }

--- a/test/resource-uri-compat.cjs
+++ b/test/resource-uri-compat.cjs
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const { ResourceRegistry } = require('../dist/resources/registry');
+const registry = new ResourceRegistry();
+for (const uriTemplate of ['cocos://node/{uuid}', 'cocos://node/{uuid}/components', 'cocos://component/{uuid}']) {
+    registry.register({ uriTemplate, name: uriTemplate, description: '', read: async params => params });
+}
+const uuid = 'example/short+uuid';
+for (const template of registry.listTemplates()) {
+    const match = registry.match(template.uriTemplate.replace('{uuid}', encodeURIComponent(uuid)));
+    assert.ok(match);
+    assert.strictEqual(match.params.uuid, uuid);
+}
+assert.strictEqual(registry.match('cocos://node/plain-uuid').params.uuid, 'plain-uuid');
+assert.strictEqual(registry.match('cocos://node/literal%252F').params.uuid, 'literal%2F');
+assert.strictEqual(registry.match('cocos://node/%ZZ'), null);
+console.log('PASS: URI parameters decode exactly once, including slash and plus in Cocos UUIDs');

--- a/test/scene-create-compat.cjs
+++ b/test/scene-create-compat.cjs
@@ -1,0 +1,58 @@
+// Run after npm run build. Also runs with Creator 3.8.3's Node 14.16.
+const assert = require('assert');
+const { SceneAdvancedTools } = require('../dist/tools/scene-advanced-tools');
+
+async function main() {
+    const originalEditor = global.Editor;
+    const originalCrypto = Object.getOwnPropertyDescriptor(global, 'crypto');
+    const scenes = [];
+    const opened = [];
+    let currentUuid = 'test-asset-uuid';
+    Object.defineProperty(global, 'crypto', { value: undefined, configurable: true });
+    global.Editor = { Message: { request: async (channel, method, ...args) => {
+        if (channel === 'scene' && method === 'query-dirty') return false;
+        if (channel === 'scene' && method === 'new-scene') throw new Error('Message does not exist: scene - new-scene');
+        if (channel === 'asset-db' && method === 'generate-available-url') return 'db://assets/NewScene.scene';
+        if (channel === 'asset-db' && method === 'create-asset') { scenes.push(JSON.parse(args[1])); return {}; }
+        if (channel === 'asset-db' && method === 'query-uuid') return 'test-asset-uuid';
+        if (channel === 'scene' && method === 'open-scene') { opened.push(args[0]); return; }
+        if (channel === 'scene' && method === 'query-node-tree') return { uuid: currentUuid };
+        throw new Error(`Unexpected message: ${channel}/${method}`);
+    } } };
+    try {
+        const tools = new SceneAdvancedTools();
+        for (const args of [{ path: 'db://assets/Compatibility.scene' }, {}]) {
+            const result = await tools.execute('scene_create', args);
+            assert.ok(!result.isError, JSON.stringify(result));
+            assert.strictEqual(JSON.parse(result.content[0].text).success, true);
+        }
+        assert.strictEqual(scenes.length, 2);
+        for (const scene of scenes) {
+            const globals = scene[scene[1]._globals.__id__];
+            assert.strictEqual(globals.__type__, 'cc.SceneGlobals');
+            for (const [field, type] of Object.entries({ ambient: 'cc.AmbientInfo', shadows: 'cc.ShadowsInfo', _skybox: 'cc.SkyboxInfo', fog: 'cc.FogInfo' })) {
+                assert.strictEqual(scene[globals[field].__id__].__type__, type);
+            }
+            const visit = value => {
+                if (!value || typeof value !== 'object') return;
+                if ('__id__' in value) assert.ok(scene[value.__id__], `Dangling reference ${value.__id__}`);
+                Object.values(value).forEach(visit);
+            };
+            visit(scene);
+        }
+        const ids = scenes.map(scene => scene.find(item => item.__type__ === 'cc.Scene')._id);
+        for (const id of ids) assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+        assert.notStrictEqual(ids[0], ids[1]);
+        assert.deepStrictEqual(opened, ['test-asset-uuid', 'test-asset-uuid']);
+        currentUuid = 'fallback-empty-scene';
+        const failedOpen = await tools.execute('scene_create', { path: 'db://assets/Failed.scene' });
+        assert.strictEqual(failedOpen.isError, true);
+        assert.match(failedOpen.content[0].text, /could not be opened/);
+        console.log('PASS: scene creation without global crypto (explicit path and 3.8.x fallback)');
+    } finally {
+        global.Editor = originalEditor;
+        if (originalCrypto) Object.defineProperty(global, 'crypto', originalCrypto);
+        else delete global.crypto;
+    }
+}
+main().catch(error => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
Creating a scene on Creator 3.8.3 fails with `crypto is not defined`. After bypassing that error, the generated scene also fails to load because its SceneGlobals references are offset by two; the tool nevertheless reports success. This change makes both explicit-path and automatic fallback scene creation produce scenes that open successfully.

- Generate RFC 4122 v4 UUIDs using Node's `crypto.randomBytes`, which works in Creator 3.8.3's embedded Node 14.16 (without global crypto or crypto.randomUUID).
- Correct SceneGlobals and environment object references, and verify the active scene UUID after opening instead of swallowing load failures.
- Decode percent-encoded resource template parameters exactly once. Real Cocos short node/component UUIDs containing `/` could not be read even when clients encoded them as `%2F`.
- Add standalone regression checks and update the outdated scene_create limitation and runtime requirements.

Validation:
- `npm run build`
- `node test/scene-create-compat.cjs`
- `node test/resource-uri-compat.cjs`
- Both compatibility checks also passed under the Node 14.16 runtime embedded in the macOS Creator 3.8.3 application.
- Live MCP testing on Creator 3.8.3: create/open scenes with and without an explicit path; create and move nodes; edit Label text/size; save scene and prefab; switch scenes and reopen; verify persisted values through URI-encoded node/component resources. The resulting scene rendered correctly in Chrome preview and was visually checked in the editor.

The full existing regression suite was not run against the user's game project. Editor-internal preview on this installation raised an `updateSize` error; browser preview worked and is the preview validation reported above. Generated distribution files are left to the normal build/release workflow (`npm run build` is required when testing this branch).

Related: #13
